### PR TITLE
Rebrand Gnosis Safe to Safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A collection of awesome tools to run a DAO
 
 ## Treasury Management 💰
 
-* [Gnosis Safe](https://gnosis-safe.io/) - The most trusted platform to manage digital assets on Ethereum.
+* [Safe](https://safe.global/) - The most trusted platform to manage digital assets on Ethereum.
 * [Coinshift](https://coinshift.xyz/) - Treasury management with multi-sig support, batch payments, and real-time reporting.
 * [Coincile](https://coincile.io/) - Unified treasury dashboards, multi-sig wallet tracking, grant management, and audit trails.
 * [Superfluid](https://www.superfluid.finance/) - Programmable money streams for real-time salary, subscriptions, and continuous token distributions.


### PR DESCRIPTION
Gnosis Safe rebranded to "Safe" in July 2022 after spinning out from Gnosis. The legacy gnosis-safe.io domain 301-redirects to safe.global today.

This PR updates the README entry under "Treasury Management" to the current brand and URL.

- Anchor text: `Safe`
- URL: https://safe.global

No other changes.

Sent on behalf of the Safe Foundation.